### PR TITLE
refactor: Extract Relation Schemas to Module Files

### DIFF
--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -19,17 +19,27 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
-import { contentSchema } from "../modules/contents/infrastructure/database/schemas/contents.schema";
+import {
+  contentRelationsSchema,
+  contentSchema,
+} from "../modules/contents/infrastructure/database/schemas/contents.schema";
 import { tmdbFetchStatusSchema } from "../modules/contents/infrastructure/database/schemas/tmdb-fetch-status.schema";
-import { peopleSchema } from "../modules/peoples/infrastructure/schemas/people.schema";
+import {
+  peopleRelationSchema,
+  peopleSchema,
+} from "../modules/peoples/infrastructure/schemas/people.schema";
 import {
   friendshipsRelationsSchema,
   friendshipsSchema,
   friendshipsStatusEnum,
 } from "../modules/users/infrastructure/database/schemas/friendships.schema";
-import { users as usersSchema } from "../modules/users/infrastructure/database/schemas/users.schema";
+import {
+  usersRelationSchema,
+  users as usersSchema,
+} from "../modules/users/infrastructure/database/schemas/users.schema";
 import {
   watchlistStatusEnum as watchlistCustomEnumImported,
+  watchlistRelationsSchema,
   watchlistSchema,
 } from "../modules/watchlist/infrastructure/schemas/watchlist.schema";
 import { watchpartySchema } from "../modules/watchparty/infrastructure/schemas/watchparty.schema";
@@ -866,46 +876,7 @@ export const refreshTokensRelations = relations(refreshTokens, ({ one }) => ({
   }),
 }));
 
-export const usersRelations = relations(users, ({ many }) => ({
-  refreshTokens: many(refreshTokens),
-  friendships_userId: many(friendships, {
-    relationName: "friendships_userId_users_id",
-  }),
-  friendships_friendId: many(friendships, {
-    relationName: "friendships_friendId_users_id",
-  }),
-  conversations: many(conversations),
-  conversationParticipants: many(conversationParticipants),
-  watchparties_createdBy: many(watchparties, {
-    relationName: "watchparties_createdBy_users_id",
-  }),
-  watchparties_leaderUserId: many(watchparties, {
-    relationName: "watchparties_leaderUserId_users_id",
-  }),
-  messages: many(messages),
-  ratings: many(ratings),
-  reviews: many(reviews),
-  watchlists: many(watchlist),
-  lists: many(lists),
-  watchpartyParticipants: many(watchpartyParticipants),
-  watchpartyInvitations_inviterId: many(watchpartyInvitations, {
-    relationName: "watchpartyInvitations_inviterId_users_id",
-  }),
-  watchpartyInvitations_inviteeId: many(watchpartyInvitations, {
-    relationName: "watchpartyInvitations_inviteeId_users_id",
-  }),
-  userActivityLogs: many(userActivityLogs),
-  userStats: many(userStats),
-  notifications_userId: many(notifications, {
-    relationName: "notifications_userId_users_id",
-  }),
-  notifications_relatedUserId: many(notifications, {
-    relationName: "notifications_relatedUserId_users_id",
-  }),
-  reviewLikes: many(reviewLikes),
-  listLikes: many(listLikes),
-  peopleLikes: many(peopleLikes),
-}));
+export const usersRelations = usersRelationSchema;
 
 export const friendshipsRelations = friendshipsRelationsSchema;
 
@@ -920,23 +891,9 @@ export const contentCreditsRelations = relations(contentCredits, ({ one }) => ({
   }),
 }));
 
-export const contentRelations = relations(content, ({ many }) => ({
-  contentCredits: many(contentCredits),
-  seasons: many(seasons),
-  watchparties: many(watchparties),
-  ratings: many(ratings),
-  reviews: many(reviews),
-  watchlists: many(watchlist),
-  listItems: many(listItems),
-  userActivityLogs: many(userActivityLogs),
-  notifications: many(notifications),
-  contentCategories: many(contentCategories),
-}));
+export const contentRelations = contentRelationsSchema;
 
-export const peopleRelations = relations(people, ({ many }) => ({
-  contentCredits: many(contentCredits),
-  peopleLikes: many(peopleLikes),
-}));
+export const peopleRelations = peopleRelationSchema;
 
 export const seasonsRelations = relations(seasons, ({ one, many }) => ({
   content: one(content, {
@@ -1071,16 +1028,7 @@ export const reviewsRelations = relations(reviews, ({ one, many }) => ({
   reviewLikes: many(reviewLikes),
 }));
 
-export const watchlistRelations = relations(watchlist, ({ one }) => ({
-  user: one(users, {
-    fields: [watchlist.userId],
-    references: [users.id],
-  }),
-  content: one(content, {
-    fields: [watchlist.contentId],
-    references: [content.id],
-  }),
-}));
+export const watchlistRelations = watchlistRelationsSchema;
 
 export const listsRelations = relations(lists, ({ one, many }) => ({
   user: one(users, {

--- a/apps/api/src/modules/contents/infrastructure/database/schemas/contents.schema.ts
+++ b/apps/api/src/modules/contents/infrastructure/database/schemas/contents.schema.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import {
   check,
   date,
@@ -12,6 +12,19 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import {
+  content,
+  contentCategories,
+  contentCredits,
+  listItems,
+  notifications,
+  ratings,
+  reviews,
+  seasons,
+  userActivityLogs,
+  watchlist,
+  watchparties,
+} from "../../../../../database/schema";
 
 export const contentSchema = pgTable(
   "content",
@@ -73,6 +86,19 @@ export const contentSchema = pgTable(
     ),
   ]
 );
+
+export const contentRelationsSchema = relations(content, ({ many }) => ({
+  contentCredits: many(contentCredits),
+  seasons: many(seasons),
+  watchparties: many(watchparties),
+  ratings: many(ratings),
+  reviews: many(reviews),
+  watchlists: many(watchlist),
+  listItems: many(listItems),
+  userActivityLogs: many(userActivityLogs),
+  notifications: many(notifications),
+  contentCategories: many(contentCategories),
+}));
 
 export type ContentRow = typeof contentSchema.$inferSelect;
 export type NewContentRow = typeof contentSchema.$inferInsert;

--- a/apps/api/src/modules/peoples/infrastructure/schemas/people.schema.ts
+++ b/apps/api/src/modules/peoples/infrastructure/schemas/people.schema.ts
@@ -1,3 +1,4 @@
+import { relations } from "drizzle-orm";
 import {
   date,
   index,
@@ -9,6 +10,11 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import {
+  contentCredits,
+  people,
+  peopleLikes,
+} from "../../../../database/schema";
 
 export const peopleSchema = pgTable(
   "people",
@@ -35,6 +41,11 @@ export const peopleSchema = pgTable(
     unique("people_tmdb_id_key").on(table.tmdbId),
   ]
 );
+
+export const peopleRelationSchema = relations(people, ({ many }) => ({
+  contentCredits: many(contentCredits),
+  peopleLikes: many(peopleLikes),
+}));
 
 export type PeopleRow = typeof peopleSchema.$inferSelect;
 export type NewPeopleRow = typeof peopleSchema.$inferInsert;

--- a/apps/api/src/modules/users/infrastructure/database/schemas/users.schema.ts
+++ b/apps/api/src/modules/users/infrastructure/database/schemas/users.schema.ts
@@ -1,4 +1,4 @@
-import { sql } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import {
   boolean,
   check,
@@ -10,6 +10,26 @@ import {
   uuid,
   varchar,
 } from "drizzle-orm/pg-core";
+import {
+  conversationParticipants,
+  conversations,
+  friendships,
+  listLikes,
+  lists,
+  messages,
+  notifications,
+  peopleLikes,
+  ratings,
+  refreshTokens,
+  reviewLikes,
+  reviews,
+  userActivityLogs,
+  userStats,
+  watchlist,
+  watchparties,
+  watchpartyInvitations,
+  watchpartyParticipants,
+} from "../../../../../database/schema";
 
 export const users = pgTable(
   "users",
@@ -57,6 +77,47 @@ export const users = pgTable(
     ),
   ]
 );
+
+export const usersRelationSchema = relations(users, ({ many }) => ({
+  refreshTokens: many(refreshTokens),
+  friendships_userId: many(friendships, {
+    relationName: "friendships_userId_users_id",
+  }),
+  friendships_friendId: many(friendships, {
+    relationName: "friendships_friendId_users_id",
+  }),
+  conversations: many(conversations),
+  conversationParticipants: many(conversationParticipants),
+  watchparties_createdBy: many(watchparties, {
+    relationName: "watchparties_createdBy_users_id",
+  }),
+  watchparties_leaderUserId: many(watchparties, {
+    relationName: "watchparties_leaderUserId_users_id",
+  }),
+  messages: many(messages),
+  ratings: many(ratings),
+  reviews: many(reviews),
+  watchlists: many(watchlist),
+  lists: many(lists),
+  watchpartyParticipants: many(watchpartyParticipants),
+  watchpartyInvitations_inviterId: many(watchpartyInvitations, {
+    relationName: "watchpartyInvitations_inviterId_users_id",
+  }),
+  watchpartyInvitations_inviteeId: many(watchpartyInvitations, {
+    relationName: "watchpartyInvitations_inviteeId_users_id",
+  }),
+  userActivityLogs: many(userActivityLogs),
+  userStats: many(userStats),
+  notifications_userId: many(notifications, {
+    relationName: "notifications_userId_users_id",
+  }),
+  notifications_relatedUserId: many(notifications, {
+    relationName: "notifications_relatedUserId_users_id",
+  }),
+  reviewLikes: many(reviewLikes),
+  listLikes: many(listLikes),
+  peopleLikes: many(peopleLikes),
+}));
 
 export type UserRow = typeof users.$inferSelect;
 export type NewUserRow = typeof users.$inferInsert;

--- a/apps/api/src/modules/watchlist/infrastructure/schemas/watchlist.schema.ts
+++ b/apps/api/src/modules/watchlist/infrastructure/schemas/watchlist.schema.ts
@@ -1,3 +1,4 @@
+import { relations } from "drizzle-orm";
 import {
   foreignKey,
   index,
@@ -8,7 +9,7 @@ import {
   unique,
   uuid,
 } from "drizzle-orm/pg-core";
-import { content, users } from "../../../../database/schema";
+import { content, users, watchlist } from "../../../../database/schema";
 
 export const watchlistStatusEnum = pgEnum("watchlistStatus", [
   "plan_to_watch",
@@ -61,6 +62,17 @@ export const watchlistSchema = pgTable(
     unique("unique_watchlist_entry").on(table.userId, table.contentId),
   ]
 );
+
+export const watchlistRelationsSchema = relations(watchlist, ({ one }) => ({
+  user: one(users, {
+    fields: [watchlist.userId],
+    references: [users.id],
+  }),
+  content: one(content, {
+    fields: [watchlist.contentId],
+    references: [content.id],
+  }),
+}));
 
 export type WatchlistRow = typeof watchlistSchema.$inferSelect;
 export type NewWatchlistRow = typeof watchlistSchema.$inferInsert;


### PR DESCRIPTION
Move relations definitions for users, content, people, and watchlist into their respective module schema files and replace inline relations in
database/schema.ts with the imported relation schemas

## Description

Brief description of changes made.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [ ] Manual testing completed

## Related Issues

Closes #[issue number]

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
