### PR TITLE
fix: Serialize category query and map to TMDB IDs

### DIFF
--- a/apps/api/src/modules/contents/application/controllers/contents.controller.ts
+++ b/apps/api/src/modules/contents/application/controllers/contents.controller.ts
@@ -66,7 +66,6 @@ export class ContentsController extends BaseController {
   queryContents = asyncHandler(
     async (req, res): Promise<QueryContentResponse> => {
       const query = req.query as QueryContentRequest;
-
       const response = await this.queryContentsUseCase.execute(query);
 
       res.status(200).json(response);

--- a/apps/api/src/modules/contents/application/dto/requests/query-contents.validator.ts
+++ b/apps/api/src/modules/contents/application/dto/requests/query-contents.validator.ts
@@ -8,7 +8,14 @@ export const queryContentRequestSchema = z.object({
   releaseDate: z.date().optional(),
   year: z.number().optional(),
   averageRating: z.number().min(0).max(10).optional(),
-  categories: z.array(z.string()).optional(),
+  categories: z
+    .preprocess((val) => {
+      if (typeof val === "string" && val.startsWith("[") && val.endsWith("]")) {
+        return val.slice(1, -1).split(",").filter(Boolean);
+      }
+      return val;
+    }, z.array(z.string()))
+    .optional(),
   withCategory: z.enum(["true", "false"]).optional(),
   withPlatform: z.enum(["true", "false"]).optional(),
   withCast: z.enum(["true", "false"]).optional(),

--- a/apps/api/src/modules/contents/infrastructure/database/repositories/contents.repository.ts
+++ b/apps/api/src/modules/contents/infrastructure/database/repositories/contents.repository.ts
@@ -96,7 +96,6 @@ export class ContentsRepository implements IContentRepository {
               season.episodes.map((ep) => new Episode(ep))
             );
           }
-          logger.info(seasonEntity.toJSONWithRelations());
           return seasonEntity;
         });
 

--- a/apps/api/src/modules/seasons/infrastructure/tmdb/seasons.tmdb.repository.ts
+++ b/apps/api/src/modules/seasons/infrastructure/tmdb/seasons.tmdb.repository.ts
@@ -37,7 +37,7 @@ export class SeasonTmdbRepository {
         seasons.push(season);
       } catch {
         logger.error(
-          `Season ${seasonNumber} not found for serie ${tmdbSerieId}           (CONTINUE)`
+          `Season ${seasonNumber} not found for serie ${tmdbSerieId} (CONTINUE)`
         );
       }
     }

--- a/apps/api/src/shared/infrastructure/repositories/base-composite-repository.ts
+++ b/apps/api/src/shared/infrastructure/repositories/base-composite-repository.ts
@@ -165,14 +165,25 @@ export abstract class BaseCompositeRepository<
   ): Promise<{ data: TEntity[]; total: number }> {
     try {
       const page = options?.page || 1;
-
+      const categoriesTmdbIds: string[] = [];
+      if (categories) {
+        for (const categoryDbId of categories) {
+          const categoryEntity =
+            await this.categoryRepository.findById(categoryDbId);
+          if (categoryEntity) {
+            const categoryEntityJson = categoryEntity.toJSON();
+            if (categoryEntityJson.tmdbId) {
+              categoriesTmdbIds.push(categoryEntityJson.tmdbId.toString());
+            }
+          }
+        }
+      }
       let tmdbResult: { ids: number[]; results: unknown[]; total: number };
-
       if (title) {
         tmdbResult = await this.tmdbRepository.search({
           query: title,
           page,
-          withCategories: categories,
+          withCategories: categoriesTmdbIds,
         });
         logger.info(
           `Found ${tmdbResult.ids.length} ${this.entityType} IDs from TMDB search for "${title}"`
@@ -180,7 +191,7 @@ export abstract class BaseCompositeRepository<
       } else {
         tmdbResult = await this.tmdbRepository.discover({
           page,
-          withCategories: categories,
+          withCategories: categoriesTmdbIds,
         });
         logger.info(
           `Found ${tmdbResult.ids.length} ${this.entityType} IDs from TMDB discover (page ${page})`

--- a/apps/api/src/shared/infrastructure/repositories/base-tmdb-repository.ts
+++ b/apps/api/src/shared/infrastructure/repositories/base-tmdb-repository.ts
@@ -93,7 +93,7 @@ export abstract class BaseTMDBRepository<
       const queryParams: Record<string, string> = {
         page: params.page.toString(),
       };
-
+      logger.info(params.withCategories);
       if (params.withCategories && params.withCategories.length > 0) {
         queryParams.with_genres = params.withCategories.join(",");
       }

--- a/apps/front/src/lib/api/services/contents/index.ts
+++ b/apps/front/src/lib/api/services/contents/index.ts
@@ -7,8 +7,13 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { contentsKeys } from "./keys";
 
-const discover = async (props: GETContentsParams) => {
-  const response = await gETContents({ ...props });
+const discover = async ({ categories, ...rest }: GETContentsParams) => {
+  const response = await gETContents({
+    ...rest,
+    ...(categories?.length
+      ? { categories: `[${categories.join(",")}]` as unknown as string[] }
+      : {}),
+  });
   return response.data.data;
 };
 

--- a/packages/api-sdk/src/axios-instance.ts
+++ b/packages/api-sdk/src/axios-instance.ts
@@ -4,4 +4,16 @@ import axios from "axios";
 export const axiosInstance = axios.create({
   baseURL: config.env.backend.apiUrl,
   withCredentials: true,
+  paramsSerializer: (params) => {
+    const parts: string[] = [];
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) continue;
+      if (Array.isArray(value)) {
+        parts.push(`${key}=[${value.join(",")}]`);
+      } else {
+        parts.push(`${key}=${value}`);
+      }
+    }
+    return parts.join("&");
+  },
 });


### PR DESCRIPTION
Accept bracketed category lists in query params (e.g. [1,2]) by preprocessing them into arrays. Add an axios paramsSerializer to emit arrays as [a,b] from the frontend. Translate stored category DB IDs to TMDB genre IDs before calling TMDB APIs. Tidy up some logger messages and remove a noisy log.

## Description

Brief description of changes made.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [ ] Added/updated unit tests
- [ ] Added/updated integration tests
- [ ] Manual testing completed

## Related Issues

Closes #[issue number]

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
